### PR TITLE
fix: add buffer require

### DIFF
--- a/src/duplex.js
+++ b/src/duplex.js
@@ -1,6 +1,7 @@
 const { Readable, Writable, Duplex } = require('stream')
 const getIterator = require('get-iterator')
 const Fifo = require('p-fifo')
+const { Buffer } = require('buffer')
 const END_CHUNK = Buffer.alloc(0)
 
 module.exports = function toDuplex (duplex, options) {

--- a/test/helpers/streams.js
+++ b/test/helpers/streams.js
@@ -4,7 +4,8 @@ const { Writable, pipeline } = require('stream')
 function pipe (...streams) {
   return new Promise((resolve, reject) => {
     pipeline(...streams, err => {
-      if (err) return reject(err)
+      // work around bug in node to make 'should end mid stream' test pass - https://github.com/nodejs/node/issues/23890
+      if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE') return reject(err)
       resolve()
     })
   })

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const { Readable } = require('stream')
+const { Buffer } = require('buffer')
 const toStream = require('../')
 const { collect } = require('./helpers/streams')
 const { randomInt, randomBytes } = require('./helpers/random')


### PR DESCRIPTION
Future versions of webpack will not bundle node internals so we have to `require` them as they won't be globals any more.

Weirdly `buffer` was already a dep of this module but wasn't used in the actual source 🤷‍♂️